### PR TITLE
Minor fix to work with abr_control

### DIFF
--- a/abr_analyze/nengo_utils/intercepts_scan.py
+++ b/abr_analyze/nengo_utils/intercepts_scan.py
@@ -72,7 +72,6 @@ def run(encoders, intercept_vals, input_signal, seed=1,
             n_output=1,  # number of output is irrelevant
             n_neurons=encoders.shape[1],
             intercepts=intercept_list,
-            probe_weights=True,
             seed=seed,
             encoders=encoders,
             **kwargs)


### PR DESCRIPTION
- also made abr_control branch, with same name, of required changes to
  pass pytests
- removed probe_weights parameter that is no longer available in
  dynamics_adaptation