### PR TITLE
Fix for Travis-CI hdf5 file creation error

### DIFF
--- a/abr_analyze/nengo_utils/intercepts_scan.py
+++ b/abr_analyze/nengo_utils/intercepts_scan.py
@@ -16,7 +16,8 @@ from abr_analyze.data_handler import DataHandler
 import abr_analyze.nengo_utils.network_utils as network_utils
 
 def run(encoders, intercept_vals, input_signal, seed=1,
-        save_name='example', notes='', analysis_fncs=None, **kwargs):
+        db_name='intercepts_scan', save_name='example', notes='',
+        analysis_fncs=None, **kwargs):
     '''
     runs a scan for the proportion of neurons that are active over time
 
@@ -92,7 +93,7 @@ def run(encoders, intercept_vals, input_signal, seed=1,
                 network_utils.n_neurons_active_and_inactive(activity=activity))
 
             if ii == 0:
-                dat = DataHandler('intercepts_scan')
+                dat = DataHandler(db_name)
                 dat.save(
                     data={'total_intercepts':len(intercept_vals),
                           'notes':notes},

--- a/abr_analyze/nengo_utils/tests/test_intercepts_scan.py
+++ b/abr_analyze/nengo_utils/tests/test_intercepts_scan.py
@@ -28,7 +28,8 @@ def test_run():
         intercept_vals=intercept_vals,
         input_signal=input_signal,
         analysis_fncs=[network_utils.proportion_time_neurons_active,
-                       network_utils.proportion_neurons_active_over_time]
+                       network_utils.proportion_neurons_active_over_time],
+        db_name='intercepts_scan_test_run',
         )
 
 


### PR DESCRIPTION
Added ability to change the name of the HDF5 file generated when using intercept scan, and specified the pytest to create it's own instance. This appears to have fixed the long-standing error.