### PR TITLE
Bug fix to plotting time

### DIFF
--- a/abr_analyze/data_handler.py
+++ b/abr_analyze/data_handler.py
@@ -509,11 +509,11 @@ class DataHandler():
         # print('session: ', session)
         if session is None or run is None:
             # if session is not None and run is None:
-            #     print('Checking for lastest run in session%03d'%session)
+            #     print('Checking for latest run in session%03d'%session)
             # elif session is None and run is not None:
             #     print('Checking for run%i data in latest session'%run)
             # else:
-            #     print('Checking for lastest session and run...')
+            #     print('Checking for latest session and run...')
             [run, session, group_path] = self.last_save_location(
                 session=session, run=run, test_name=test_name,
                 test_group=test_group, create=create)

--- a/abr_analyze/plotting/draw_2d_data.py
+++ b/abr_analyze/plotting/draw_2d_data.py
@@ -81,6 +81,13 @@ class Draw2dData(DrawData):
                     ax=ax, x=self.data[save_name]['cumulative_time'][:step],
                     y=self.data[save_name][param][:step], c=c,
                     linestyle=linestyle, label=label, title=title)
+            elif len(parameters) == 1 and parameters[0] == 'time':
+                ax = vis.plot_2d_data(
+                    ax=ax,
+                    y=self.data[save_name]['time'][:step], c=c,
+                    linestyle=linestyle, title=title,
+                    label='%s: %.2fms'
+                    % (label, 1000*np.mean(self.data[save_name]['time'])))
 
         # ax.set_xlim(self.xlimit[0], self.xlimit[1])
         # ax.set_ylim(self.ylimit[0], self.ylimit[1])


### PR DESCRIPTION
Minimal code change, should be a quick review

- Default behaviour is to pass something to plot along with time, for this
reason time has been ignored as y data and has always been used for x
- Now if only time is passed in it will be plotting on y, and the legend
  will show the average loop speed